### PR TITLE
Settings: Fix removal of notification pulse LED preference

### DIFF
--- a/src/com/android/settings/notification/ConfigureNotificationSettings.java
+++ b/src/com/android/settings/notification/ConfigureNotificationSettings.java
@@ -27,6 +27,7 @@ import android.os.UserHandle;
 import android.os.UserManager;
 import android.provider.Settings;
 import android.support.v7.preference.Preference;
+import android.support.v7.preference.PreferenceCategory;
 import android.support.v7.preference.Preference.OnPreferenceChangeListener;
 import android.support.v7.preference.TwoStatePreference;
 import android.util.Log;
@@ -112,15 +113,16 @@ public class ConfigureNotificationSettings extends SettingsPreferenceFragment {
     // === Pulse notification light ===
 
     private void initPulse() {
+        final PreferenceCategory category = (PreferenceCategory) findPreference("lights");
         mNotificationPulse =
-                (TwoStatePreference) getPreferenceScreen().findPreference(KEY_NOTIFICATION_PULSE);
+                (TwoStatePreference) category.findPreference(KEY_NOTIFICATION_PULSE);
         if (mNotificationPulse == null) {
             Log.i(TAG, "Preference not found: " + KEY_NOTIFICATION_PULSE);
             return;
         }
         if (!getResources()
                 .getBoolean(com.android.internal.R.bool.config_intrusiveNotificationLed)) {
-            getPreferenceScreen().removePreference(mNotificationPulse);
+            category.removePreference(mNotificationPulse);
         } else {
             updatePulse();
             mNotificationPulse.setOnPreferenceChangeListener(new OnPreferenceChangeListener() {


### PR DESCRIPTION
Patch fc108b737494232efc6328d69f2802c8476ea6ca moved the preference
into a category. Update code to reflect this.

Change-Id: Ib3d4c110f9b2e4c4e039507535a70b8f172ea9ac