### PR TITLE
Settings: Disable lock screen blur by default

### DIFF
--- a/res/xml/security_settings_password_sub.xml
+++ b/res/xml/security_settings_password_sub.xml
@@ -61,7 +61,6 @@
         <cyanogenmod.preference.CMSecureSettingSwitchPreference
             android:key="lock_screen_blur_enabled"
             android:title="@string/lockscreen_blur_enabled_title"
-            android:defaultValue="true"
             cm:requiresConfig="@*android:bool/config_uiBlurEnabled" />
 
 </PreferenceScreen>

--- a/res/xml/security_settings_pattern_sub.xml
+++ b/res/xml/security_settings_pattern_sub.xml
@@ -65,7 +65,6 @@
         <cyanogenmod.preference.CMSecureSettingSwitchPreference
             android:key="lock_screen_blur_enabled"
             android:title="@string/lockscreen_blur_enabled_title"
-            android:defaultValue="true"
             cm:requiresConfig="@*android:bool/config_uiBlurEnabled" />
 
 </PreferenceScreen>

--- a/res/xml/security_settings_pin_sub.xml
+++ b/res/xml/security_settings_pin_sub.xml
@@ -66,7 +66,6 @@
         <cyanogenmod.preference.CMSecureSettingSwitchPreference
             android:key="lock_screen_blur_enabled"
             android:title="@string/lockscreen_blur_enabled_title"
-            android:defaultValue="true"
             cm:requiresConfig="@*android:bool/config_uiBlurEnabled" />
 
 </PreferenceScreen>

--- a/res/xml/security_settings_slide_sub.xml
+++ b/res/xml/security_settings_slide_sub.xml
@@ -45,7 +45,6 @@
         <cyanogenmod.preference.CMSecureSettingSwitchPreference
             android:key="lock_screen_blur_enabled"
             android:title="@string/lockscreen_blur_enabled_title"
-            android:defaultValue="true"
             cm:requiresConfig="@*android:bool/config_uiBlurEnabled" />
 
 </PreferenceScreen>


### PR DESCRIPTION
This is a controversial feature.

Not all users like it, especially due to the fact that a user's
desktop is somewhat visible with it.

Depends on change I544c413e1be9ad52d75b0df23aa7cef426aaf80a.

Change-Id: I557f3956de53bda3d709ddcc5a513ca37c8a5b53