### PR TITLE
Back-port ag/2491664

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -86,6 +86,7 @@
     <uses-permission android:name="android.permission.PEERS_MAC_ADDRESS"/>
     <uses-permission android:name="android.permission.MANAGE_NOTIFICATIONS"/>
     <uses-permission android:name="android.permission.DELETE_PACKAGES"/>
+    <uses-permission android:name="android.permission.HIDE_NON_SYSTEM_OVERLAY_WINDOWS" />
 
     <uses-permission android:name="cyanogenmod.permission.PROTECTED_APP" />
     <uses-permission android:name="cyanogenmod.permission.WRITE_SETTINGS" />

--- a/src/com/android/settings/accessibility/ToggleAccessibilityServicePreferenceFragment.java
+++ b/src/com/android/settings/accessibility/ToggleAccessibilityServicePreferenceFragment.java
@@ -39,6 +39,8 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.MotionEvent;
 import android.view.View;
+import android.view.Window;
+import android.view.WindowManager;
 import android.view.accessibility.AccessibilityManager;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
@@ -54,6 +56,8 @@ import com.android.settings.widget.ToggleSwitch.OnBeforeCheckedChangeListener;
 import com.android.settingslib.accessibility.AccessibilityUtils;
 
 import java.util.List;
+
+import static android.view.WindowManager.LayoutParams.PRIVATE_FLAG_HIDE_NON_SYSTEM_OVERLAY_WINDOWS;
 
 public class ToggleAccessibilityServicePreferenceFragment
         extends ToggleFeaturePreferenceFragment implements DialogInterface.OnClickListener {
@@ -178,6 +182,10 @@ public class ToggleAccessibilityServicePreferenceFragment
 
                 ad.create();
                 ad.getButton(AlertDialog.BUTTON_POSITIVE).setOnTouchListener(filterTouchListener);
+                Window window = ad.getWindow();
+                WindowManager.LayoutParams params = window.getAttributes();
+                params.privateFlags |= PRIVATE_FLAG_HIDE_NON_SYSTEM_OVERLAY_WINDOWS;
+                window.setAttributes(params);
                 return ad;
             }
             case DIALOG_ID_DISABLE_WARNING: {


### PR DESCRIPTION
Bug: 62196835
Test: Verify overlays disappear on a11y capabilities
dialog.

Change-Id: Ic675012dd9faa8e53d1d4b126b3ba68fecdab992
(cherry picked from commit e76e053595660ed2a75adb33ee124a7bfbed164b)