### PR TITLE
DevelopmentSettings: Fix possible NPE

### DIFF
--- a/src/com/android/settings/Utils.java
+++ b/src/com/android/settings/Utils.java
@@ -791,7 +791,7 @@ public final class Utils extends com.android.settingslib.Utils {
     static boolean isOemUnlockEnabled(Context context) {
         PersistentDataBlockManager manager =(PersistentDataBlockManager)
                 context.getSystemService(Context.PERSISTENT_DATA_BLOCK_SERVICE);
-        return manager.getOemUnlockEnabled();
+        return manager != null && manager.getOemUnlockEnabled();
     }
 
     /**


### PR DESCRIPTION
* getSystemService() can return null if the service is not
  available
* Check this before accessing a method
* Edge case: This code is usually not called on every device

Change-Id: I722638f2647dde7fb7d6a9a29c4a0e82314231c7