### PR TITLE
Reword bluetooth confirmation dialog

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1352,7 +1352,7 @@
     <string name="bluetooth_display_passkey_pin_msg">To pair with:<xliff:g id="bold1">&lt;br>&lt;b></xliff:g><xliff:g id="device_name">%1$s</xliff:g><xliff:g id="end_bold1">&lt;/b>&lt;br>&lt;br></xliff:g>Type on it:<xliff:g id="bold2">&lt;br>&lt;b></xliff:g><xliff:g id="passkey">%2$s</xliff:g><xliff:g id="end_bold2">&lt;/b></xliff:g>, then press Return or Enter.</string>
 
     <!-- Checkbox message in pairing dialogs.  [CHAR LIMIT=NONE] -->
-    <string name="bluetooth_pairing_shares_phonebook">Allow <xliff:g id="device_name">%1$s</xliff:g> to access your contacts and call history</string>
+    <string name="bluetooth_pairing_shares_phonebook">Allow access to your contacts and call history</string>
 
     <!-- Title for BT error dialogs. -->
     <string name="bluetooth_error_title"></string>


### PR DESCRIPTION
Changing the text near the checkbox allowing contacts/call history
access from "Allow $device_name to access your contacts and call
history" to just "Allow access to your contacts and call history" to
avoid problem where a properly crafted remote device name can make the
"to access your contacts and call history" text get pushed down below
the fold, and mislead users into thinking the checkbox has a different
meaning.

Bug: 62672248
Test: manual (initiate bluetooth pairing with another phone or a
computer, observe pairing dialog text)

Change-Id: I770852739f6791c2b9a36ab45c526bab3f3b9be1
(cherry picked from commit e14d38a3833676a9ee36155371136b83c4bfadb7)